### PR TITLE
Proposals List - Soft Delete

### DIFF
--- a/modules/proposals/proposals.server.controller.js
+++ b/modules/proposals/proposals.server.controller.js
@@ -93,13 +93,19 @@ exports.list = function (req, res) {
 	let solutionId = req.query.solutionId || null;
 	let search = req.query.search || null;
 	let org = req.query.organization || null;
+	let showDeleted = req.query.showDeleted || null;
 
 	let orgMatch = org ? { 'organizations.url': org } : {};
 	let solutionMatch = solutionId ? { 'solutions': mongoose.Types.ObjectId(solutionId) } : {};
 	let searchMatch = search ? { $text: { $search: search } } : {};
 
+	let showNonDeletedItemsMatch = { $or: [{ 'softDeleted': false }, { 'softDeleted': { $exists: false } }] };
+	let showAllItemsMatch = {};
+	let softDeleteMatch = showDeleted ? showAllItemsMatch : showNonDeletedItemsMatch;
+
 	Proposal.aggregate([
 			{ $match: searchMatch },
+			{ $match: softDeleteMatch },
 			{ $match: solutionMatch },
 			{
 				$lookup: {


### PR DESCRIPTION
I couldn't reproduce the issue on the main UQ site with the counter showing proposals / solutions. There doesn't seem to be any proposals on that site. 

I found Solutions that were soft deleted on my local instance of NewVote were not being counter but proposals were.