### PR TITLE
Redirects

### DIFF
--- a/modules/proposals/proposals.server.controller.js
+++ b/modules/proposals/proposals.server.controller.js
@@ -32,10 +32,18 @@ exports.create = function(req, res) {
 
     // Return votes without an _id - as it cannot be deleted
     // _id being preset prevents copying and saving of vote data between collections
-    const votePromise = Vote.find({
-        object: req.body.suggestionTemplate._id,
-        objectType: 'Suggestion'
-    }).select('-_id -created');
+    const votePromise = new Promise((resolve, reject) => {
+        if (req.body.suggestionTemplate) {
+            return resolve(
+                Vote.find({
+                    object: req.body.suggestionTemplate._id || false,
+                    objectType: 'Suggestion'
+                }).select('-_id -created')
+            )
+        }
+
+        return resolve(false);
+    })
 
     Promise.all([proposalPromise, votePromise])
         .then(promises => {

--- a/modules/solutions/solutions.server.controller.js
+++ b/modules/solutions/solutions.server.controller.js
@@ -31,16 +31,24 @@ exports.create = function(req, res) {
         resolve(solution);
     });
 
-    const votePromise = Vote.find({
-        object: req.body.suggestionTemplate._id,
-        objectType: 'Suggestion'
-    }).select('-_id -created');
+    const votePromise = new Promise((resolve, reject) => {
+        if (req.body.suggestionTemplate) {
+            return resolve(
+                Vote.find({
+                    object: req.body.suggestionTemplate._id || false,
+                    objectType: 'Suggestion'
+                }).select('-_id -created')
+            )
+        }
+
+        return resolve(false);
+    })
 
     Promise.all([solutionPromise, votePromise])
         .then(promises => {
             const [solution, votes] = promises;
 
-            if (!solution) throw 'Solution failed to save';
+            if (!solution) throw 'Solution failed to create';
 
             if (votes.length > 0) {
                 const convertSuggestionVotesToSolution = votes


### PR DESCRIPTION
Fixes issue when creating solution/proposal that content `req.body` required `suggestionTemplate` property.

`votePromise` was always running and would search for suggestion votes even if suggestionTemplate was not present.