### PR TITLE
Owner Verification fix

### DIFF
--- a/modules/generic.server.policy.js
+++ b/modules/generic.server.policy.js
@@ -193,7 +193,9 @@ exports.isAllowed = async function (req, res, next) {
 // this is NOT the organization that the content belongs to (not the object.organizations)
 // N.B new content will have no organization
 async function canAccessOrganization(req, object) {
-    if (!checkUrl(req)) throw('Invalid Domain');
+    // Check the session url against the request url (via referrer)
+    // If not matching reject
+    if (!checkUrl(req)) throw('Session domain does not match request');
 
     const { organization: reqOrg } = req;
     if (!reqOrg) throw('No organization discovered in request body')
@@ -250,7 +252,6 @@ function checkUrl (req) {
     url = url.replace(/(^\w+:|^)\/\//, '');
     const [domain, ...rest] = url.split('.');
     
-    console.log(domain === organization.url, 'this is organization url from cookie');
     return domain === organization.url
 }
 

--- a/modules/generic.server.policy.js
+++ b/modules/generic.server.policy.js
@@ -156,8 +156,6 @@ exports.isAllowed = async function (req, res, next) {
                 !user.roles.includes('user') ||
                 !user.verified
             ) {
-
-                console.log('failed at verification & loggged in');
                 // user is logged in but they are missing the user role
                 // this means they must not be verified
                 return res.status(403).json({
@@ -176,14 +174,12 @@ exports.isAllowed = async function (req, res, next) {
                         return next();
                     })
                     .catch((err) => {
-                        console.log(err, 'this is err on can access');
                         return res.status(403).json({
                             message: err
                         });
                     });
             } 
 
-            console.log('FAiled at end')
             // this is a GET request with a user object that was not allowed
             // generic auth failure
             return res.status(403).json({
@@ -254,9 +250,7 @@ function checkUrl (req) {
     url = url.replace(/(^\w+:|^)\/\//, '');
     const [domain, ...rest] = url.split('.');
     
-    console.log(domain, 'this is domain');
-    console.log(organization, 'this is organization url from cookie');
-
+    console.log(domain === organization.url, 'this is organization url from cookie');
     return domain === organization.url
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
             "dependencies": {
                 "ajv": {
                     "version": "6.4.0",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.4.0.tgz",
+                    "resolved": "http://registry.npmjs.org/ajv/-/ajv-6.4.0.tgz",
                     "integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
                     "dev": true,
                     "requires": {
@@ -989,7 +989,7 @@
         },
         "@types/q": {
             "version": "0.0.32",
-            "resolved": "https://registry.npmjs.org/@types/q/-/q-0.0.32.tgz",
+            "resolved": "http://registry.npmjs.org/@types/q/-/q-0.0.32.tgz",
             "integrity": "sha1-vShOV8hPEyXacCur/IKlMoGQwMU=",
             "dev": true
         },
@@ -1180,7 +1180,7 @@
         },
         "ansi-colors": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+            "resolved": "http://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
             "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
             "dev": true,
             "requires": {
@@ -1522,7 +1522,7 @@
             "dependencies": {
                 "browserslist": {
                     "version": "0.4.0",
-                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-0.4.0.tgz",
+                    "resolved": "http://registry.npmjs.org/browserslist/-/browserslist-0.4.0.tgz",
                     "integrity": "sha1-O9SrkZncG5FQ1NbbpNnTqrvIbdQ=",
                     "dev": true,
                     "requires": {
@@ -1920,7 +1920,7 @@
                 },
                 "readable-stream": {
                     "version": "1.1.14",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                     "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                     "requires": {
                         "core-util-is": "~1.0.0",
@@ -2079,7 +2079,7 @@
         },
         "chalk": {
             "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
             "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
             "requires": {
                 "ansi-styles": "^2.2.1",
@@ -2805,7 +2805,7 @@
                 },
                 "readable-stream": {
                     "version": "2.3.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
@@ -3054,7 +3054,7 @@
             "dependencies": {
                 "bluebird": {
                     "version": "2.11.0",
-                    "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+                    "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
                     "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
                 }
             }
@@ -3508,7 +3508,7 @@
                 },
                 "readable-stream": {
                     "version": "1.1.14",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                     "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                     "requires": {
                         "core-util-is": "~1.0.0",
@@ -3611,7 +3611,7 @@
         },
         "duplexer": {
             "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+            "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
             "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
             "dev": true
         },
@@ -3630,7 +3630,7 @@
                 },
                 "readable-stream": {
                     "version": "1.1.14",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                     "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                     "requires": {
                         "core-util-is": "~1.0.0",
@@ -3864,7 +3864,7 @@
         },
         "es6-promise": {
             "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
+            "resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
             "integrity": "sha1-7FYjOGgDKQkgcXDDlEjiREndH8Q="
         },
         "es6-promisify": {
@@ -5335,7 +5335,7 @@
                 },
                 "readable-stream": {
                     "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
@@ -5411,7 +5411,7 @@
             "dependencies": {
                 "ansi-regex": {
                     "version": "0.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                    "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                     "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk=",
                     "dev": true
                 },
@@ -5423,7 +5423,7 @@
                 },
                 "chalk": {
                     "version": "0.5.1",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+                    "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
                     "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
                     "dev": true,
                     "requires": {
@@ -5547,7 +5547,7 @@
                 },
                 "minimist": {
                     "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
+                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
                     "integrity": "sha1-Tf/lJdriuGTGbC4jxicdev3s784=",
                     "dev": true
                 },
@@ -5559,7 +5559,7 @@
                 },
                 "readable-stream": {
                     "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
@@ -5586,7 +5586,7 @@
                 },
                 "strip-ansi": {
                     "version": "0.3.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                    "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                     "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
                     "dev": true,
                     "requires": {
@@ -5665,7 +5665,7 @@
                 },
                 "event-stream": {
                     "version": "3.3.4",
-                    "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+                    "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
                     "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
                     "dev": true,
                     "requires": {
@@ -6857,7 +6857,7 @@
         },
         "jsonfile": {
             "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+            "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
             "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
             "requires": {
                 "graceful-fs": "^4.1.6"
@@ -7435,7 +7435,7 @@
         },
         "load-json-file": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+            "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
             "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
             "dev": true,
             "requires": {
@@ -8105,7 +8105,7 @@
         },
         "mkdirp": {
             "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
             "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
             "requires": {
                 "minimist": "0.0.8"
@@ -8174,7 +8174,7 @@
         },
         "mock-fs": {
             "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-3.4.0.tgz",
+            "resolved": "http://registry.npmjs.org/mock-fs/-/mock-fs-3.4.0.tgz",
             "integrity": "sha1-HOBB0tfu40JC0oXCqeOOE6sLzWw=",
             "dev": true,
             "requires": {
@@ -8550,7 +8550,7 @@
         },
         "multer": {
             "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/multer/-/multer-1.0.6.tgz",
+            "resolved": "http://registry.npmjs.org/multer/-/multer-1.0.6.tgz",
             "integrity": "sha1-UmUk9r9Zo4pU4GISCLXQpU9Qen0=",
             "requires": {
                 "append-field": "^0.1.0",
@@ -9047,7 +9047,7 @@
         },
         "os-locale": {
             "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+            "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
             "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
             "dev": true,
             "requires": {
@@ -9159,7 +9159,7 @@
         },
         "passport": {
             "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/passport/-/passport-0.2.2.tgz",
+            "resolved": "http://registry.npmjs.org/passport/-/passport-0.2.2.tgz",
             "integrity": "sha1-nDjxe+uSnz2Br3uIOOhDDbhwPys=",
             "requires": {
                 "passport-strategy": "1.x.x",
@@ -9210,7 +9210,7 @@
         },
         "passport-jwt": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/passport-jwt/-/passport-jwt-4.0.0.tgz",
+            "resolved": "http://registry.npmjs.org/passport-jwt/-/passport-jwt-4.0.0.tgz",
             "integrity": "sha512-BwC0n2GP/1hMVjR4QpnvqA61TxenUMlmfNjYNgK0ZAs0HK4SOQkHcSv4L328blNTLtHq7DbmvyNJiH+bn6C5Mg==",
             "requires": {
                 "jsonwebtoken": "^8.2.0",
@@ -9246,7 +9246,7 @@
             "dependencies": {
                 "passport": {
                     "version": "0.1.18",
-                    "resolved": "https://registry.npmjs.org/passport/-/passport-0.1.18.tgz",
+                    "resolved": "http://registry.npmjs.org/passport/-/passport-0.1.18.tgz",
                     "integrity": "sha1-yCZEedy2QUytu2Z1LRKzfgtlJaE=",
                     "requires": {
                         "pause": "0.0.1",
@@ -9391,7 +9391,7 @@
         },
         "pause-stream": {
             "version": "0.0.11",
-            "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+            "resolved": "http://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
             "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
             "dev": true,
             "requires": {
@@ -9501,7 +9501,7 @@
         },
         "postcss": {
             "version": "4.1.16",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.1.16.tgz",
+            "resolved": "http://registry.npmjs.org/postcss/-/postcss-4.1.16.tgz",
             "integrity": "sha1-TESbTIr53zyvbTf44eV10DYXWNw=",
             "dev": true,
             "requires": {
@@ -9512,7 +9512,7 @@
             "dependencies": {
                 "es6-promise": {
                     "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
+                    "resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
                     "integrity": "sha1-lu258v2wGZWCKyY92KratnSBgbw=",
                     "dev": true
                 },
@@ -10677,7 +10677,7 @@
         },
         "should-equal": {
             "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-0.5.0.tgz",
+            "resolved": "http://registry.npmjs.org/should-equal/-/should-equal-0.5.0.tgz",
             "integrity": "sha1-x5fxNfMGf+tp6+zbMGscP+IbPm8=",
             "dev": true,
             "requires": {
@@ -11178,7 +11178,7 @@
         },
         "stream-combiner": {
             "version": "0.0.4",
-            "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+            "resolved": "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
             "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
             "dev": true,
             "requires": {
@@ -11287,7 +11287,7 @@
         },
         "strip-ansi": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "requires": {
                 "ansi-regex": "^2.0.0"
@@ -11347,7 +11347,7 @@
                 },
                 "readable-stream": {
                     "version": "2.3.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "requires": {
                         "core-util-is": "~1.0.0",
@@ -11523,7 +11523,7 @@
         },
         "through": {
             "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
             "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
             "dev": true
         },
@@ -12102,7 +12102,7 @@
         },
         "validator": {
             "version": "3.43.0",
-            "resolved": "https://registry.npmjs.org/validator/-/validator-3.43.0.tgz",
+            "resolved": "http://registry.npmjs.org/validator/-/validator-3.43.0.tgz",
             "integrity": "sha1-lkZLmS1BloM9l6GUv0Cxn/VLrgU="
         },
         "value-or-function": {
@@ -12173,7 +12173,7 @@
                 },
                 "readable-stream": {
                     "version": "2.3.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
@@ -12379,7 +12379,7 @@
         },
         "wrap-ansi": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+            "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
             "dev": true,
             "requires": {


### PR DESCRIPTION
When we were checking the users `_id` against the owners `_id` the comparison was failing due to an issue with object id's not being strings. So used the `.equals` method which seems to have fixed the issue. 

Also created a `checkUrl` function which compares the current `organization.url` with the request refferer url to try and find the source of the request. However I believe in production this had some issues as I think https requests do not contain a referrer header. 